### PR TITLE
Create FAIR data.md

### DIFF
--- a/docs/bouwblokken/data/FAIR data.md
+++ b/docs/bouwblokken/data/FAIR data.md
@@ -1,0 +1,6 @@
+---
+title: FAIR data
+summary: FAIR Guiding Principles
+---
+
+Het doel van de principes voor FAIR data is waardevolle data vindbaar, toegankelijk, interoperabel en herbruikbaar maken binnen en buiten de eigen organisatie. Nadrukkelijk niet alleen voor menselijke gebruikers maar juist ook voor machines. Voldoen aan de principes voor FAIR data maakt data "machine actionable", daarom wordt het acronym FAIR ook wel uitgelegd als "Fully AI Ready". De principes voor FAIR data worden beheerd door de Nedelndse stichting [GO FAIR Foundation](https://www.gofair.foundation/). De naleving van de FAIR Guiding Principes krijgt een wettelijke grondslag in de Wet Hergebruik Overheidsinformatie.


### PR DESCRIPTION
Een pagina over de principes voor FAIR data en wat deze voor het ontwikkelen en gebruiken van AI kunnen betekenen lijkt mij hier op zijn plaats. De principes voor FAIR data krijgen in elk geval een plaats in het (interne) gegevensbeleid van en voor BZK dat nu dooor CIO&I wordt ontwikkeld. Daarnaast werkt CIO&I aan (intern) AI beleid (werktitel) van en voor BZK, gericht op het op verantwoorde wijze kunnen benutten van de kansen die AI biedt. Het beleid van CIO&I beoogt vooral de organisatie praktische handvatten te bieden. Ik werk deze pagina bij gebleken belangstelling graag verder uit.

Norbert van Dijk
CIO-adviseur data & AI CIO&I BZK