### PR TITLE
Fix preview.yaml for forked repos

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -41,6 +41,7 @@ jobs:
           path: ./site/
 
       - name: Deploy preview
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./site/


### PR DESCRIPTION
As discussed in [git push origin HEAD](https://github.com/MinBZK/Algoritmekader/issues/79). Only run the `Deploy Preview` action in preview.yaml when the PR is from the current repository. 