### PR TITLE
Taalfoutjes

### DIFF
--- a/docs/levenscyclus/archiveren.md
+++ b/docs/levenscyclus/archiveren.md
@@ -2,7 +2,7 @@
 title: Archiveren
 ---
 
-Wanneer het AI-model niet langer nodig is of wordt vervangen door een verbeterde versie, wordt het gearchiveerd. Dit omvat het behouden van documentatie en eventuele relevante artefacten.
+Wanneer het algoritme of AI-model niet langer nodig is of wordt vervangen door een verbeterde versie, wordt het gearchiveerd. Dit omvat het behouden van documentatie en eventuele relevante artefacten.
  
 ## Vereisten
 

--- a/docs/levenscyclus/implementatie.md
+++ b/docs/levenscyclus/implementatie.md
@@ -2,7 +2,7 @@
 title: Implementatie
 ---
 
-In deze fase wordt het AI-model in de praktijk gebracht en geïntegreerd in het bedrijfsproces. Het wordt operationeel en begint te werken met echte gegevens.
+In deze fase wordt het algoritme of AI-model in de praktijk gebracht en geïntegreerd in het bedrijfsproces. Het wordt operationeel en begint te werken met echte gegevens.
 
 ## Vereisten
 

--- a/docs/levenscyclus/monitoren.md
+++ b/docs/levenscyclus/monitoren.md
@@ -2,7 +2,7 @@
 title: Monitoren
 ---
 
-Het AI-model wordt voortdurend gemonitord om ervoor te zorgen dat het blijft presteren zoals verwacht. Eventuele afwijkingen of degradatie van prestaties worden geïdentificeerd en aangepakt.
+Het algoritme of AI-model wordt voortdurend gemonitord om ervoor te zorgen dat het blijft presteren zoals verwacht. Eventuele afwijkingen of degradatie van prestaties worden geïdentificeerd en aangepakt.
 
 ## Vereisten
 

--- a/docs/levenscyclus/monitoren.md
+++ b/docs/levenscyclus/monitoren.md
@@ -2,7 +2,7 @@
 title: Monitoren
 ---
 
-Het algoritme of AI-model wordt voortdurend gemonitord om ervoor te zorgen dat het blijft presteren zoals verwacht. Eventuele afwijkingen of degradatie van prestaties worden geïdentificeerd en aangepakt.
+Het algoritme of AI-model wordt voortdurend gemonitord om ervoor te zorgen dat het blijft presteren zoals verwacht. Eventuele afwijkingen of verslechtering van prestaties worden geïdentificeerd en aangepakt.
 
 ## Vereisten
 

--- a/docs/levenscyclus/ontwerp.md
+++ b/docs/levenscyclus/ontwerp.md
@@ -2,7 +2,7 @@
 title: Ontwerp
 ---
 
-Hier wordt het conceptuele ontwerp van het AI-systeem gemaakt. Dit omvat het bepalen van de architectuur, algoritmen en benodigde middelen voor de implementatie.
+Hier wordt het conceptuele ontwerp van het algoritme of AI-systeem gemaakt. Dit omvat het bepalen van de architectuur, algoritmen en benodigde middelen voor de implementatie.
 
 ## Vereisten
 

--- a/docs/overhetalgoritmekader/index.md
+++ b/docs/overhetalgoritmekader/index.md
@@ -21,7 +21,7 @@ Het is ook mogelijk om vanuit een specifieke rol, bijvoorbeeld een ethicus of da
 
 ### Type technologie en risicoclassificatie
 Het Algoritmekader geeft gebruikers de mogelijkheid om informatie te 'filteren'. 
-Dit kan bijvoorbeeld worden gedaan op basis van type technologie en risico classificatie. 
+Dit kan bijvoorbeeld worden gedaan op basis van type technologie en risicoclassificatie. 
 Zo kunnen gebruikers snel zien wat zij in een bepaalde situaties moeten doen. 
 In het geval van een hoge risico AI-systeem waarbij persoonsgegevens worden verwerkt zullen aan meer vereisten moeten worden voldaan dan in het geval van een eenvoudige rekenregel die geen impact heeft op individuen of de maatschappij. 
 Deze inzichten moeten overheidsorganisaties helpen om effectief en gericht hun middelen in te kunnen zetten. 
@@ -48,9 +48,8 @@ Overheden wordt aanbevolen het kader te volgen, maar mogen te allen tijde zelf b
 Kortom, de vereisten zijn verplicht en de maatregelen (hoe kan hieraan worden voldaan aan de vereisten) zijn ter inspiratie om organisaties op weg te helpen.  
 
 ## Doorontwikkeling
-7 juli 2023 is het [concept Implementatiekader](https://www.rijksoverheid.nl/documenten/rapporten/2023/06/30/implementatiekader-verantwoorde-inzet-van-algoritmen) naar de kamer verstuurd, vergezeld door de Kamerbrief 'Verzamelbrief Algoritmes Reguleren'. 
-Dit kan worden beschouwd als de eerste versie van het Algoritmekader. H
-et implementatiekader verantwoorde inzet van algoritmen is in oktober 2023 hernoemd naar 'het Algoritmekader'. 
+7 juli 2023 is de [eerste versie van het Implementatiekader](https://www.rijksoverheid.nl/documenten/rapporten/2023/06/30/implementatiekader-verantwoorde-inzet-van-algoritmen) naar de Tweede Kamer verstuurd, vergezeld door de Kamerbrief 'Verzamelbrief algoritmen reguleren'. 
+Dit kan worden beschouwd als de eerste versie van het Algoritmekader. Het implementatiekader verantwoorde inzet van algoritmen is in oktober 2023 hernoemd naar 'het Algoritmekader'. 
 
 In oktober 2023 is gestart met de doorontwikkeling van het Algoritmekader, zowel op inhoud als op vorm. Dat betekent dat inhoudelijke toevoegingen worden gedaan (denk aan hetgeen voortkomt uit de AI-verordening) en er wordt onderzocht hoe informatie zo optimaal mogelijk aan gebruikers getoond kan worden. 
 Het doel is dat het Algoritmekader gebruikers op een praktische wijze helpt bij het uitvoeren van hun werkzaamheden. 
@@ -58,7 +57,7 @@ Het interactief kunnen doorzoeken van de informatie is daar een voorbeeld van.
 
 Eind 2024 zal de tweede versie van het Algoritmekader worden opgeleverd. 
 Dan moeten de vereisten en de maatregelen zijn uitgewerkt voor zover dan bekend. 
-Hierna zal het Algoritmekader in 'beheer' worden genomen. Dat betekent dat doorlopend de laatste ontwikkelingen, blijvend in afstemming met de omgeving, worden toegevoegd zodat het Algoritmekader actueel en betrouwbaar blijft.  
+Hierna zal het Algoritmekader in 'beheer' worden genomen. Dat betekent dat doorlopend de laatste ontwikkelingen, gin afstemming met de omgeving, worden toegevoegd zodat het Algoritmekader actueel en betrouwbaar blijft.  
 
 ## Samenwerking met de omgeving
 Een belangrijk uitgangspunt van het Algoritmekader is dat het kader op een open en transparante manier wordt ontwikkeld. 

--- a/docs/overhetalgoritmekader/index.md
+++ b/docs/overhetalgoritmekader/index.md
@@ -57,7 +57,7 @@ Het interactief kunnen doorzoeken van de informatie is daar een voorbeeld van.
 
 Eind 2024 zal de tweede versie van het Algoritmekader worden opgeleverd. 
 Dan moeten de vereisten en de maatregelen zijn uitgewerkt voor zover dan bekend. 
-Hierna zal het Algoritmekader in 'beheer' worden genomen. Dat betekent dat doorlopend de laatste ontwikkelingen, gin afstemming met de omgeving, worden toegevoegd zodat het Algoritmekader actueel en betrouwbaar blijft.  
+Hierna zal het Algoritmekader in 'beheer' worden genomen. Dat betekent dat doorlopend de laatste ontwikkelingen, in afstemming met de omgeving, worden toegevoegd zodat het Algoritmekader actueel en betrouwbaar blijft.  
 
 ## Samenwerking met de omgeving
 Een belangrijk uitgangspunt van het Algoritmekader is dat het kader op een open en transparante manier wordt ontwikkeld. 


### PR DESCRIPTION
Taalfoutjes in voorpagina Github eruitgehaald.

Daarnaast 'algoritme' toegevoegd waar alleen AI-model genoemd werd bij fasen van de levenscyclus.