### PR TITLE
toevoegen functionaliteit van rollen en eerste bestanden van rollen

### DIFF
--- a/docs/rollen/communicatieadviseur.md
+++ b/docs/rollen/communicatieadviseur.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Communicatieadviseur
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/communicatieadviseur -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/communicatieadviseur -->
 
 !!! info "Disclaimer"
 

--- a/docs/rollen/domeinspecialist.md
+++ b/docs/rollen/domeinspecialist.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Domeinspecialist
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/domeinspecialist -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/domeinspecialist -->
 
 !!! info "Disclaimer"
 

--- a/docs/rollen/index.md
+++ b/docs/rollen/index.md
@@ -26,4 +26,4 @@ Hier wordt wel al verwezen naar het nog te ontwikkelen gedeelte [Governance](../
 Aan dit bouwblok wordt onmiddels gewerkt. 
 
 !!! note "Opmerking"
-    Hier volgt in een volgende versie een opsomming van de verschillende rollen. 
+    Er is al een aantal rollen toegevoegd aan het algoritmekader. Dit wordt nog aangvuld, en de rollen worden nog gekoppeld aan vereisten en maatregelen. 

--- a/docs/rollen/informatiebeheerder.md
+++ b/docs/rollen/informatiebeheerder.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Informatiebeheerder
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/informatiebeheerder -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/informatiebeheerder -->
 
 !!! info "Disclaimer"
 

--- a/docs/rollen/inkoopadviseur.md
+++ b/docs/rollen/inkoopadviseur.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Inkoopadviseur
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/inkoopadviseur -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/inkoopadviseur -->
 
 !!! info "Disclaimer"
 

--- a/docs/rollen/privacy-officer.md
+++ b/docs/rollen/privacy-officer.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Privacy-officer
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/privacy-officer -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/privacy-officer -->
 
 !!! info "Disclaimer"
 

--- a/docs/rollen/projectleider.md
+++ b/docs/rollen/projectleider.md
@@ -1,14 +1,14 @@
 ---
-title: Data scientist
+title: Projectleider
 ---
 
 ## Vereisten
 
-<!-- list_vereisten rollen/data-scientist -->
+<!-- list_vereisten rollen/projectleider -->
 
 ## Maatregelen
 
-<!-- list_maatregelen rollen/data-scientist -->
+<!-- list_maatregelen rollen/projectleider -->
 
 !!! info "Disclaimer"
 

--- a/docs/vereisten/geb_dpia_verplicht_bij_hoog_risico.md
+++ b/docs/vereisten/geb_dpia_verplicht_bij_hoog_risico.md
@@ -11,6 +11,8 @@ levenscyclus:
 - validatie
 bouwblok: 
 - privacy-en-gegevensbescherming
+rollen:
+- privacy-officer
 rekenregels: 
 - niet-impactvol: Nee
 - impactvol: Ja

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
         - bouwblokken/index.md
         - ... | bouwblokken/*/*.md
     - Rollen:
-        - rollen/index.md
+        - ... | rollen/*.md
     - Vereisten:
         - ... | vereisten/*.md
     - Maatregelen:

--- a/src/overrides/hooks/tags.py
+++ b/src/overrides/hooks/tags.py
@@ -112,7 +112,7 @@ def _badge_rollen(page: Page, files: Files, rol: str):
     return _badge(
         icon=f"[:{icon}:]({href_rol} 'Rollen')",
         text=f"[{rol.capitalize().replace('-', ' ')}]({href_fase})",
-        color="green",
+        color="deep-orange",
     )
 
 


### PR DESCRIPTION
## Beschrijf jouw aanpassingen
- functionaliteit van rollen toegevoegd
- kleur van de tags van rollen aangepast
- bestanden van rollen worden automatisch getoond onder 'rollen'
- eerste bestanden van rollen toegevoegd

Wanneer je in de metadata van een vereiste of maatregel rollen meegeeft, worden deze automatisch getoond als tag: 
![afbeelding](https://github.com/MinBZK/Algoritmekader/assets/71120805/40ceb861-77f4-4e57-837c-f949510d3b42)

Toevoegen in de metatdata kan als volgt: 
![afbeelding](https://github.com/MinBZK/Algoritmekader/assets/71120805/1a07fb95-f3b0-430a-9d1b-03fb6bdf5402)

De gekoppelde vereisten en rollen worden dan automatisch weergegeven op de pagina van de desbetreffende rol 

Let op! Je kan alleen rollen toevoegen die ook zijn aangemaakt als pagina in de map rollen. 

## Bij welk issue hoort deze pull-request?
#94 

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).
