### PR TITLE
Controleren of de wet wordt gevolgd is niet het doel van het register

### DIFF
--- a/docs/maatregelen/publiceren_in_algoritmeregister.md
+++ b/docs/maatregelen/publiceren_in_algoritmeregister.md
@@ -35,7 +35,7 @@ hide:
 
 ## Toelichting
 - De regering wil dat de overheid algoritmes en AI-systemen verantwoord gebruikt. Mensen moeten erop kunnen vertrouwen dat algoritmes voldoen aan de waarden en normen van de samenleving.
-- Wanneer de overheid open is over algoritmes en hun toepassing, kunnen burgers, organisaties en media haar kritisch volgen en controleren of ze de wet en de regels volgt.
+- Wanneer de overheid open is over algoritmes en hun toepassing, kunnen burgers, organisaties en media haar kritisch volgen.
 - Impactvolle algoritmes en hoog risico AI-systemen moeten daarom worden gepubliceerd in het Algoritmeregister.
 - In het Algoritmeregister moet uitleg zijn over hoe algoritmes en AI-systemen, of het proces wat hiermee wordt ondersteund werkt.
 - Er is een Handreiking Algoritmeregister opgesteld met informatie over het publiceren van algoritmes en AI-systemen in het Algoritmeregister.

--- a/docs/maatregelen/publiceren_in_algoritmeregister.md
+++ b/docs/maatregelen/publiceren_in_algoritmeregister.md
@@ -20,7 +20,7 @@ bouwblok:
 rollen:
 - proceseigenaar
 - beleidsmedewerker
-- privacy officer
+- privacy-officer
 - aanbieder
   
 hide:


### PR DESCRIPTION
Het controledoel van het register is geschrapt. Bron: https://github.com/MinBZK/Algoritmeregister/commit/1d1edb70c1354ae90b860d78b4c7724b6041b040#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7

## Beschrijf jouw aanpassingen
Schrap de vermelding dat mensen kunnen controleren of bestuursorganen de wet en de regels volgen aan de hand van het register.

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
- [x] Deze pull-request gaat naar de juiste branch (in principe mergen we eerst naar de branch `release` alvorens te mergen naar de `main` branch).
