### PR TITLE
Update aia-07-automatische-logregistratie.md

### DIFF
--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-07-automatische-logregistratie.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-07-automatische-logregistratie.md
@@ -1,5 +1,5 @@
 ---
-title: Hoog-risico AI-systemen loggen automatisch bepaalde gegevens
+title: Hoog-risico-AI-systemen loggen automatisch bepaalde gegevens
 id: urn:nl:ak:ver:aia-07
 toelichting: AI-systemen met een hoog risico zijn dusdanig technisch vormgegeven dat gebeurtenissen gedurende hun levenscyclus automatisch worden geregistreerd (“logs”).
 levenscyclus:


### PR DESCRIPTION
Verbindingsstreepje toegevoegd.

Overigens lijkt de H1 hier te ontbreken om de een of andere reden. Heb geen H1 toegevoegd, want kwam dit ook op andere pagina's tegen. Begint de pagina straks echt met een H2 (en slaat dus de H1 over), dan is 'ie niet toegankelijk.

## Beschrijf jouw aanpassingen

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
