### PR TITLE
Update aia-18-corrigerende-maatregelen-voor-non-conforme-ai.md

### DIFF
--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-18-corrigerende-maatregelen-voor-non-conforme-ai.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-18-corrigerende-maatregelen-voor-non-conforme-ai.md
@@ -1,5 +1,5 @@
 ---
-title: Als een hoog-risico AI-systeem niet voldoet aan de AI-verordening, grijpt de aanbieder in
+title: Als een hoog-risico-AI-systeem niet voldoet aan de AI-verordening, grijpt de aanbieder in
 id: urn:nl:ak:ver:aia-18
 toelichting: Aanbieders van AI-systemen met een hoog risico die van mening zijn of redenen hebben om aan te nemen dat een door hen in de handel gebracht of in gebruik gesteld AI systeem met een hoog risico niet in overeenstemming is met de AI-verordening, nemen onmiddellijk de nodige corrigerende maatregelen om dat systeem naargelang het geval in overeenstemming te brengen, uit de handel te nemen, te deactiveren of terug te roepen. Zij stellen de distributeurs van het betrokken AI-systeem met een hoog risico en, indien van toepassing, de gebruiksverantwoordelijken, de gemachtigden en importeurs dienovereenkomstig in kennis.
 levenscyclus:


### PR DESCRIPTION
Verbindingsstreepje toegevoegd (belangrijk voor zoekfunctie en woordenlijst).

Overigens lijkt de H1 hier te ontbreken om de een of andere reden. Heb geen H1 toegevoegd, want kwam dit ook op andere pagina's tegen. Begint de pagina straks echt met een H2 (en slaat dus de H1 over), dan is 'ie niet toegankelijk.

## Beschrijf jouw aanpassingen

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
