### PR TITLE
Voeg labels toe aan vereisten voor filtering beslishulp

### DIFF
--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-00-verboden-AI-praktijken.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-00-verboden-AI-praktijken.md
@@ -16,6 +16,20 @@ risicogroep:
 rol-ai-act:
 - aanbieder
 - gebruiksverantwoordelijke
+- importeur
+- distributeur
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-01-ai-geletterdheid.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-01-ai-geletterdheid.md
@@ -15,9 +15,27 @@ risicogroep:
 - hoog-risico-ai-systeem
 - verboden-ai
 - geen-hoog-risico-ai-systeem
+- niet-van-toepassing
 rol-ai-act:
 - aanbieder
 - gebruiksverantwoordelijke
+- importeur
+- distributeur
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-02-documentatie-beoordeling-niet-hoog-risico-ai.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-02-documentatie-beoordeling-niet-hoog-risico-ai.md
@@ -14,6 +14,18 @@ risicogroep:
 - geen-hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-03-risicobeheersysteem.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-03-risicobeheersysteem.md
@@ -13,6 +13,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-04-risicobeoordeling-voor-jongeren-en-kwetsbaren.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-04-risicobeoordeling-voor-jongeren-en-kwetsbaren.md
@@ -16,6 +16,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-05-data-kwaliteitscriteria.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-05-data-kwaliteitscriteria.md
@@ -17,6 +17,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-06-technische-documentatie.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-06-technische-documentatie.md
@@ -16,6 +16,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-07-automatische-logregistratie.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-07-automatische-logregistratie.md
@@ -14,6 +14,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-08-transparantie-aan-gebruiksverantwoordelijken.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-08-transparantie-aan-gebruiksverantwoordelijken.md
@@ -15,6 +15,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-09-menselijk-toezicht.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-09-menselijk-toezicht.md
@@ -17,6 +17,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-10-nauwkeurigheid-robuustheid-cyberbeveiliging.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-10-nauwkeurigheid-robuustheid-cyberbeveiliging.md
@@ -15,6 +15,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-11-systeem-voor-kwaliteitsbeheer.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-11-systeem-voor-kwaliteitsbeheer.md
@@ -13,6 +13,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-12-bewaartermijn-voor-documentatie.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-12-bewaartermijn-voor-documentatie.md
@@ -16,6 +16,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-13-bewaartermijn-voor-gegenereerde-logs.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-13-bewaartermijn-voor-gegenereerde-logs.md
@@ -15,6 +15,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-14-conformiteitsbeoordeling.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-14-conformiteitsbeoordeling.md
@@ -15,6 +15,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-15-eu-conformiteitsverklaring.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-15-eu-conformiteitsverklaring.md
@@ -14,6 +14,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-16-ce-markering.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-16-ce-markering.md
@@ -13,6 +13,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-17-registratieverplichtingen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-17-registratieverplichtingen.md
@@ -13,6 +13,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - aanbieder
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-18-corrigerende-maatregelen-voor-non-conforme-ai.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-18-corrigerende-maatregelen-voor-non-conforme-ai.md
@@ -15,6 +15,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-19-toegankelijkheidseisen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-19-toegankelijkheidseisen.md
@@ -14,6 +14,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-20-gebruiksverantwoordelijken-maatregelen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-20-gebruiksverantwoordelijken-maatregelen.md
@@ -16,6 +16,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-21-gebruiksverantwoordelijken-menselijk-toezicht.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-21-gebruiksverantwoordelijken-menselijk-toezicht.md
@@ -14,6 +14,17 @@ soort-toepassing:
 - ai-systeem-voor-algemene-doeleinden
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 rol-ai-act:
 - gebruiksverantwoordelijke
 hide:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-22-gebruiksverantwoordelijken-monitoren-werking.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-22-gebruiksverantwoordelijken-monitoren-werking.md
@@ -15,6 +15,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-23-gebruiksverantwoordelijken-bewaren-logs.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-23-gebruiksverantwoordelijken-bewaren-logs.md
@@ -16,6 +16,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-24-informeren-werknemers.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-24-informeren-werknemers.md
@@ -15,6 +15,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-25-gebruiksverantwoordelijken-registratieverplichtingen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-25-gebruiksverantwoordelijken-registratieverplichtingen.md
@@ -19,6 +19,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-26-recht-op-uitleg-ai-besluiten.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-26-recht-op-uitleg-ai-besluiten.md
@@ -19,6 +19,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-27-beoordelen-gevolgen-grondrechten.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-27-beoordelen-gevolgen-grondrechten.md
@@ -17,6 +17,18 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - gebruiksverantwoordelijke
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-28-transparantieverplichtingen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-28-transparantieverplichtingen.md
@@ -17,6 +17,15 @@ rol-ai-act:
 - aanbieder
 transparantieverplichting:
 - transparantieverplichting
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 rollen:
 - projectleider
 - ontwikkelaar

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-29-ai-modellen-algemene-doeleinden.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-29-ai-modellen-algemene-doeleinden.md
@@ -14,6 +14,19 @@ soort-toepassing:
 - ai-model-voor-algemene-doeleinden
 rol-ai-act:
 - aanbieder
+risicogroep: 
+- niet-van-toepassing
+transparantieverplichting: 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-30-ai-modellen-algemene-doeleinden-systeemrisico.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-30-ai-modellen-algemene-doeleinden-systeemrisico.md
@@ -10,8 +10,18 @@ soort-toepassing:
 - ai-model-voor-algemene-doeleinden
 rol-ai-act:
 - aanbieder
+risicogroep: 
+- niet-van-toepassing
 systeemrisico:
 - systeemrisico
+transparantieverplichting: 
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- "uitzondering-van-toepassing"
 onderwerp:
 - technische-robuustheid-en-veiligheid
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-31-ai-modellen-algemene-doeleinden-systeemrisico-ernstige-incidenten.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-31-ai-modellen-algemene-doeleinden-systeemrisico-ernstige-incidenten.md
@@ -13,8 +13,18 @@ soort-toepassing:
 - ai-model-voor-algemene-doeleinden
 rol-ai-act:
 - aanbieder
+risicogroep: 
+- niet-van-toepassing
 systeemrisico:
 - systeemrisico
+transparantieverplichting: 
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- "uitzondering-van-toepassing"
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-32-ai-modellen-algemene-doeleinden-systeemrisico-cyberbeveiliging.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-32-ai-modellen-algemene-doeleinden-systeemrisico-cyberbeveiliging.md
@@ -13,8 +13,18 @@ soort-toepassing:
 - ai-model-voor-algemene-doeleinden
 rol-ai-act:
 - aanbieder
+risicogroep: 
+- niet-van-toepassing
 systeemrisico:
 - systeemrisico
+transparantieverplichting: 
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- "uitzondering-van-toepassing"
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-33-verwerking-in-testomgeving.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-33-verwerking-in-testomgeving.md
@@ -20,6 +20,25 @@ soort-toepassing:
 rol-ai-act:
 - aanbieder
 - gebruiksverantwoordelijke
+risicogroep: 
+- niet-van-toepassing
+- hoog-risico-ai-systeem
+- geen-hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-34-monitoring-na-het-in-de-handel-brengen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-34-monitoring-na-het-in-de-handel-brengen.md
@@ -15,6 +15,17 @@ rol-ai-act:
 - aanbieder
 risicogroep:
 - hoog-risico-ai-systeem
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-35-melding-ernstige-incidenten.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-35-melding-ernstige-incidenten.md
@@ -16,6 +16,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-36-melding-inbreuk-op-ai-verordening.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-36-melding-inbreuk-op-ai-verordening.md
@@ -17,6 +17,27 @@ soort-toepassing:
 rol-ai-act:
 - aanbieder
 - gebruiksverantwoordelijke
+- importeur
+- distributeur
+risicogroep:
+- hoog-risico-ai-systeem
+- geen-hoog-risico-ai-systeem
+- niet-van-toepassing
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-37-recht-klacht-indienen-bij-ai-bureau.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-37-recht-klacht-indienen-bij-ai-bureau.md
@@ -8,6 +8,31 @@ onderwerp:
 - fundamentele-rechten
 rollen:
 - projectleider
+soort-toepassing:
+- ai-systeem
+- ai-systeem-voor-algemene-doeleinden
+- ai-model-voor-algemene-doeleinden
+rol-ai-act:
+- aanbieder
+risicogroep:
+- hoog-risico-ai-systeem
+- geen-hoog-risico-ai-systeem
+- niet-van-toepassing
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+- niet-van-toepassing
+systeemrisico:
+- systeemrisico
+- geen-systeemrisico
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
+- ("ai-systeem-voor-algemene-doeleinden" || "ai-systeem") && "open-source" && "geen-transparantieverplichting" && "geen-hoog-risico-ai-systeem"
 hide:
 - navigation
 ---

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-38-testen.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-38-testen.md
@@ -16,6 +16,17 @@ risicogroep:
 - hoog-risico-ai-systeem
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 rollen:

--- a/docs/voldoen-aan-wetten-en-regels/vereisten/aia-39-beleid-naleven-auteurs-en-naburige-rechten.md
+++ b/docs/voldoen-aan-wetten-en-regels/vereisten/aia-39-beleid-naleven-auteurs-en-naburige-rechten.md
@@ -12,8 +12,21 @@ rollen:
 - projectleider
 soort-toepassing:
 - ai-model-voor-algemene-doeleinden
+risicogroep: 
+- niet-van-toepassing
 rol-ai-act:
 - aanbieder
+transparantieverplichting: 
+- geen-transparantieverplichting
+- transparantieverplichting 
+systeemrisico:
+- niet-van-toepassing
+open-source: 
+- open-source
+- geen-open-source
+- niet-van-toepassing
+uitzondering: 
+- uitzondering-van-toepassing
 hide:
 - navigation
 ---


### PR DESCRIPTION
## Beschrijf jouw aanpassingen

Doordat we ervoor hadden gekozen om de "lege" metadata altijd te laten zien, bleken combinaties van labels geen goed filtering te hebben. Hierdoor stel ik voor om aan elke vereisten uit de AIA de mogelijke labels toe te voegen. 

Let op: 
- We zouden naar mijn mening de categorieën "operationeel" en "conformiteitsbeoordelingsinstantie" van de beslishulp helemaal buiten de filteren kunnen beschouwen (dus ze niet ophalen uit de beslishulp en ze ook niet uitvragen zonder beslishulp).
- Open-source wordt alleen indirect gebruikt voor filtering (in het geval van een uitzondering), deze hoeft dus ook niet terug te komen in het geval van uitvraag zonder beslishulp. Als gebruikers weten dat ze in een uitzondering vallen, zullen ze dit zelf aanklikken. 
- Het is van belang dat risicogroep en transparantieverplichting beide enkel kunnen gelden voor AI-systeem of AI-systeem voor algemene doeleinden. Systeemrisico kan enkel gelden voor AI-model voor algemene doeleinden. Is het mogelijk om vragen automatisch in te vullen (niet-van-toepassing) op basis van het antwoord op welke toepassing het is of te disabelen? Zo niet, zou het fijn zijn dit met een [i]tje erbij te zetten @uittenbroekrobbert 
- Moeten we voor filtering dan ook labels toevoegen aan de andere vereisten? Die niet van de AIA zijn? 

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
