### PR TITLE
Fix typo and menu bar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ hide:
     <ul>
       <li><a href="soorten-algoritmes-en-ai/wat-is-een-algoritme/">Wat is een algoritme?</a></li>
       <li><a href="soorten-algoritmes-en-ai/generatieve-ai/">Generatieve AI</a></li>
-       <li><a href="soorten-algoritmes-en-ai/risico-van-ai-systemen/">Risico van AI-systemen</a></li>
+      <li><a href="soorten-algoritmes-en-ai/risico-van-ai-systemen/">Risico van AI-systemen</a></li>
     </ul>
     
   </div>

--- a/docs/voldoen-aan-wetten-en-regels/ai-verordening.md
+++ b/docs/voldoen-aan-wetten-en-regels/ai-verordening.md
@@ -6,7 +6,7 @@ hide: navigation
 
 
 # AI-verordening in het kort
-In de EU-verordening staan de Europese regels voor het verantwoord ontwikkelen en gebruiken van AI. Sommige AI-systemen zijn verboden vanaf 2 februari 2025. Andere AI-systemen moeten op zijn laatst in 2026 of 2030 voldoen aan bepaalde vereisten.
+In de AI-verordening staan de Europese regels voor het verantwoord ontwikkelen en gebruiken van AI. Sommige AI-systemen zijn verboden vanaf 2 februari 2025. Andere AI-systemen moeten op zijn laatst in 2026 of 2030 voldoen aan bepaalde vereisten.
 
 [Verordening (EU) 2024/1689 (AI-verordening)](https://eur-lex.europa.eu/legal-content/NL/TXT/?uri=CELEX:32024R1689)
 
@@ -19,7 +19,7 @@ De AI-verordening geldt in deze 3 situaties samen:
 * Dit doe je namens een overheid, bedrijf of andere organisatie.
 * Je organisatie is gevestigd in een EU-land.
 
-Het maakt niet uit waar je AI-producten ontwikkelt. Ontwikkel je buiten de EU, maar is je organisatie gevestigd in een EU-land? Dan geldt de EU-verordening.
+Het maakt niet uit waar je AI-producten ontwikkelt. Ontwikkel je buiten de EU, maar is je organisatie gevestigd in een EU-land? Dan geldt de AI-verordening.
   
 
 ## Verantwoord gebruik van AI

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
          - soorten-algoritmes-en-ai/wat-is-een-algoritme.md
          - soorten-algoritmes-en-ai/risico-van-ai-systemen.md
          - soorten-algoritmes-en-ai/impact-van-algoritmes.md
+         - soorten-algoritmes-en-ai/generatieve-ai.md
          - soorten-algoritmes-en-ai/definities.md
     - Onderwerpen:
         # - Overzicht: onderwerpen/index.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Algoritmekader",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Beschrijf jouw aanpassingen

In deze PR: 
- Fixen we een typo "EU-verordening" naar "AI-verordening"
- Fixen we dat de menu-bar wordt laten zien in op de generatieve AI pagina. 

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
