### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ hide:
 <div class="float-container">
 
  <div class="float-child styled-list">
-    <img src="afbeeldingen/rollen.jpg" alt="Een groep mensen overlegt in een vergaderruimte." class="block-image">
+    <img src="afbeeldingen/rollen.jpg" alt=" " class="block-image">
     <div class="float-box">
     <h3><b>Soorten algoritmes en AI</b></h3>
     <ul>
@@ -36,7 +36,7 @@ hide:
   </div>
 
   <div class="float-child styled-list">
-    <img src="afbeeldingen/wetten-en-regels.jpg" alt="Standbeeld van Vrouwe Justitia met een weegschaal en zwaard." class="block-image">
+    <img src="afbeeldingen/wetten-en-regels.jpg" alt=" " class="block-image">
     <div class="float-box">
     <h3><b>Voldoen aan wetten en regels</b></h3>
     <ul>
@@ -49,7 +49,7 @@ hide:
   </div>
 
  <div class="float-child styled-list">
-    <img src="afbeeldingen/eu.jpeg" alt="Binnenzijde van een gebouw met rijen vlaggen van EU-lidstaten." class="block-image">
+    <img src="afbeeldingen/eu.jpeg" alt=" " class="block-image">
     <div class="float-box">
     <h3><b>Europese AI-verordening</b></h3>
     <ul>
@@ -62,7 +62,7 @@ hide:
   </div>
 
   <div class="float-child styled-list">
-    <img src="afbeeldingen/onderwerpen.jpg" alt="Persoon typt op een toetsenbord met meerdere computerschermen waarop code zichtbaar is." class="block-image">
+    <img src="afbeeldingen/onderwerpen.jpg" alt=" " class="block-image">
     <div class="float-box">
     <h3><b>Onderwerpen</b></h3>
     <ul>


### PR DESCRIPTION
De alt-teksten van de 4 afbeeldingen op de homepage moeten leegblijven want deze zijn decoratief. Alleen informatieve afbeeldingen krijgen een alt-tekst.

Bron: https://www.w3.org/WAI/WCAG22/quickref/#non-text-content > Decoration, Formatting, Invisible: If non-text content is pure decoration, is used only for visual formatting, or is not presented to users, then it is implemented in a way that it can be ignored by assistive technology.

## Beschrijf jouw aanpassingen
Ik heb dit aangepast door een spatie te plaatsen.

## Bij welk issue hoort deze pull-request?
#677 

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd. 
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader. 
