### PR TITLE
Replace html tags with mkdocs native

### DIFF
--- a/docs/levenscyclus/over-de-levenscyclus.md
+++ b/docs/levenscyclus/over-de-levenscyclus.md
@@ -13,17 +13,15 @@ Om algoritmes op een verantwoorde manier te gebruiken, zul je op de juiste momen
 
 ## Fases van de levenscyclus
 
-<ol start="0">
-  <li> <a href="organisatieverantwoordelijkheden.md">Organisatieverantwoordelijkheden</a></li>
-  <li> <a href="probleemanalyse.md">Probleemanalyse</a></li>
-  <li> <a href="ontwerp.md">Ontwerp</a></li>
-  <li> <a href="dataverkenning-en-datapreparatie.md">Dataverkenning en datapreparatie</a></li>
-  <li> <a href="ontwikkelen.md">Ontwikkelen</a></li>
-  <li> <a href="verificatie-en-validatie.md">Verificatie en validatie</a></li>
-  <li> <a href="implementatie.md">Implementeren</a></li>
-  <li> <a href="monitoring-en-beheer.md">Monitoring en beheer</a></li>
-  <li> <a href="uitfaseren.md">Uitfaseren</a></li>
-</ol>
+0. [Organisatieverantwoordelijkheden](organisatieverantwoordelijkheden.md)
+1. [Probleemanalyse](probleemanalyse.md)
+2. [Ontwerp](ontwerp.md)
+3. [Dataverkenning en datapreparatie](dataverkenning-en-datapreparatie.md)
+4. [Ontwikkelen](ontwikkelen.md)
+5. [Verificatie en validatie](verificatie-en-validatie.md)
+6. [Implementeren](implementatie.md)
+7. [Monitoring en beheer](monitoring-en-beheer.md)
+8. [Uitfaseren](uitfaseren.md)
 
 ## Systeemniveau en organisatieniveau
 De levenscyclus kent 2 verschillende niveau's:


### PR DESCRIPTION
## Beschrijf jouw aanpassingen

- docs/levenscyclus/over-de-levenscyclus.md: Geordende HTML lijst < ol start="0" > met 9 < li > items vervangen door Markdown genummerde lijst (0-8)
- docs/index.md: HTML lijsten behouden - deze hebben speciale CSS styling (styled-list klassen) voor de homepage weergave
-  Alle <a> tags met JavaScript functionaliteit behouden - Deze zijn bedoeld voor modal dialogs (onclick="showModal(...)) en kunnen/moeten niet vervangen worden
- Alle standaard navigatielinks gebruiken al correcte Markdown syntaxis [text] (url)
- Geen eenvoudige anchor tags gevonden die vervangen konden worden

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader.
