### PR TITLE
Beslishulp naar v1.2.24

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -31,7 +31,13 @@ RUN rm -f site/sitemap.xml.gz
 # pinned by tag + digest. Inherits the nginx-unprivileged entrypoint, so the
 # envsubst-on-templates + .envsh mechanism still works. We ship our own
 # nginx.conf / security-headers.conf / server template on top.
-FROM ghcr.io/rijksictgilde/nginx-base:2026.06.17@sha256:529cb9e17264ce479d19b408530d2e33b217225d60e9fd320257aed0cdbfa377
+#
+# Let op: upstream bewaart maar ~30 datum-tags (~5 weken). Een pin die ouder
+# is verdwijnt uit het register en de build faalt dan met "not found" -- niet
+# met een waarschuwing. Dependabot (ecosystem "docker", directory /container)
+# ververst dit wekelijks, maar pas zodra dit bestand op de default branch
+# staat; Dependabot kijkt niet naar feature branches.
+FROM ghcr.io/rijksictgilde/nginx-base:2026.07.29@sha256:2b40227d90e8b1072c31585f31ff50baddf34579da294dd6f1e785c385bbead0
 COPY --from=builder /app/site /usr/share/nginx/html
 COPY container/nginx.conf /etc/nginx/nginx.conf
 COPY container/security-headers.conf /etc/nginx/security-headers.conf

--- a/docs/html/beslishulp.html
+++ b/docs/html/beslishulp.html
@@ -6,7 +6,7 @@
                 data-showCloseOnEndMsg="Bekijk de vereisten in het Algoritmekader"
                 data-showExportPDF="true"
                 data-showExplanationField="true"
-                src="https://github.com/MinBZK/ai-verordening-beslishulp/releases/download/v1.2.15/index.js">
+                src="https://github.com/MinBZK/ai-verordening-beslishulp/releases/download/v1.2.24/index.js">
             </script>
         </div>
     </body>

--- a/docs/javascripts/modal.js
+++ b/docs/javascripts/modal.js
@@ -308,6 +308,11 @@ class ValueMapper {
     if (this.map.has(value.toLowerCase())) {
       return this.map.get(value.toLowerCase());
     }
+    // Een onbekend label wordt verderop door updateLabels() weggefilterd op
+    // "[onbekend]". Dat is bedoeld gedrag, maar zonder waarschuwing verdwijnt
+    // een hele filterdimensie ongemerkt zodra de beslishulp een subcategorie of
+    // antwoord hernoemt. Zie tests/modal/test_beslishulp_contract.py.
+    console.warn(`labelMapper: onbekend label "${value}"; dit label filtert niet mee.`);
     return {"label": value, group: "onbekend", "display_value": value + " [onbekend]", "missing": true};
   }
 
@@ -323,10 +328,13 @@ labelMapper.addEntry('verboden-ai', 'Verboden AI', 'risicogroep', ['Risicogroep-
 labelMapper.addEntry('uitzondering-van-toepassing', 'Uitzondering van toepassing', 'risicogroep', ["Risicogroep-uitzondering van toepassing"]);
 labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'risicogroep', ["Risicogroep-niet van toepassing"]);
 
-labelMapper.addEntry('aanbieder', 'Aanbieder', 'rol-ai-act', ["Rol-aanbieder"]);
-labelMapper.addEntry('gebruiksverantwoordelijke', 'Gebruiksverantwoordelijke', 'rol-ai-act', ["Rol-gebruiksverantwoordelijke"])
-labelMapper.addEntry('importeur', 'Importeur', 'rol-ai-act', ["Rol-importeur"]);
-labelMapper.addEntry('distributeur', 'Distributeur', 'rol-ai-act', ["Rol-distributeur"]);
+// De beslishulp hernoemde de subcategorie "Rol" naar "Verantwoordelijkheid" in
+// v1.2.15. Beide blijven staan: oude naam voor sessionStorage die nog van een
+// eerdere versie komt, nieuwe naam voor de huidige beslishulp.
+labelMapper.addEntry('aanbieder', 'Aanbieder', 'rol-ai-act', ["Rol-aanbieder", "Verantwoordelijkheid-aanbieder"]);
+labelMapper.addEntry('gebruiksverantwoordelijke', 'Gebruiksverantwoordelijke', 'rol-ai-act', ["Rol-gebruiksverantwoordelijke", "Verantwoordelijkheid-gebruiksverantwoordelijke"])
+labelMapper.addEntry('importeur', 'Importeur', 'rol-ai-act', ["Rol-importeur", "Verantwoordelijkheid-importeur"]);
+labelMapper.addEntry('distributeur', 'Distributeur', 'rol-ai-act', ["Rol-distributeur", "Verantwoordelijkheid-distributeur"]);
 
 labelMapper.addEntry('ai-systeem', 'AI Systeem', 'soort-toepassing', ['Soort toepassing-AI-Systeem']);
 labelMapper.addEntry('ai-systeem-voor-algemene-doeleinden', 'AI Systeem voor algemene doeleinden', 'soort-toepassing', ['Soort toepassing-AI-Systeem voor algemene doeleinden']);

--- a/docs/javascripts/modal.js
+++ b/docs/javascripts/modal.js
@@ -322,6 +322,10 @@ class ValueMapper {
 // Usage example:
 const labelMapper = new ValueMapper();
 
+// Elke subcategorie heeft een 'niet-van-toepassing'-entry: de beslishulp zet bij
+// de conclusie iedere subcategorie die niet aan bod kwam op "niet van toepassing".
+// updateLabels() filtert die daarna weg op display_value, maar zonder entry komen
+// ze eerst als onbekend label langs en waarschuwt find() bij elke doorloop.
 labelMapper.addEntry('hoog-risico-ai-systeem', 'Hoog risico AI Systeem', 'risicogroep', ['Risicogroep-hoog-risico AI']);
 labelMapper.addEntry('geen-hoog-risico-ai-systeem', 'Geen hoog-risico AI Systeem', 'risicogroep', ['Risicogroep-geen hoog-risico AI']);
 labelMapper.addEntry('verboden-ai', 'Verboden AI', 'risicogroep', ['Risicogroep-Verboden AI']);
@@ -335,11 +339,13 @@ labelMapper.addEntry('aanbieder', 'Aanbieder', 'rol-ai-act', ["Rol-aanbieder", "
 labelMapper.addEntry('gebruiksverantwoordelijke', 'Gebruiksverantwoordelijke', 'rol-ai-act', ["Rol-gebruiksverantwoordelijke", "Verantwoordelijkheid-gebruiksverantwoordelijke"])
 labelMapper.addEntry('importeur', 'Importeur', 'rol-ai-act', ["Rol-importeur", "Verantwoordelijkheid-importeur"]);
 labelMapper.addEntry('distributeur', 'Distributeur', 'rol-ai-act', ["Rol-distributeur", "Verantwoordelijkheid-distributeur"]);
+labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'rol-ai-act', ["Rol-niet van toepassing", "Verantwoordelijkheid-niet van toepassing"]);
 
 labelMapper.addEntry('ai-systeem', 'AI Systeem', 'soort-toepassing', ['Soort toepassing-AI-Systeem']);
 labelMapper.addEntry('ai-systeem-voor-algemene-doeleinden', 'AI Systeem voor algemene doeleinden', 'soort-toepassing', ['Soort toepassing-AI-Systeem voor algemene doeleinden']);
 labelMapper.addEntry('ai-model-voor-algemene-doeleinden', 'AI model voor algemene doeleinden', 'soort-toepassing', ['Soort toepassing-AI-model voor algemene doeleinden']);
 labelMapper.addEntry('geen-algoritme', 'Geen algoritme', 'soort-toepassing', ["Soort toepassing-geen algoritme"]);
+labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'soort-toepassing', ["Soort toepassing-niet van toepassing"]);
 
 labelMapper.addEntry('transparantieverplichting', 'Transparantieverplichting', 'transparantieverplichting', ["Transparantieverplichting-transparantieverplichting"]);
 labelMapper.addEntry('geen-transparantieverplichting', 'Geen transparantieverplichting', 'transparantieverplichting', ["Transparantieverplichting-geen transparantieverplichting"]);
@@ -355,6 +361,7 @@ labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'open-source'
 
 labelMapper.addEntry('in-gebruik', 'In gebruik', 'operationeel', ["Operationeel-in gebruik"]);
 labelMapper.addEntry('in-ontwikkeling', 'In ontwikkeling', 'operationeel', ["Operationeel-in ontwikkeling"]);
+labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'operationeel', ["Operationeel-niet van toepassing"]);
 
 labelMapper.addEntry('beoordeling-door-derde-partij', 'Beoordeling door derde partij', 'conformiteitsbeoordelingsinstantie', ["Conformiteitsbeoordelingsinstantie-beoordeling door derde partij"]);
 labelMapper.addEntry('niet-van-toepassing', 'Niet van toepassing', 'conformiteitsbeoordelingsinstantie', ["Conformiteitsbeoordelingsinstantie-niet van toepassing"]);

--- a/tests/modal/test_beslishulp_contract.py
+++ b/tests/modal/test_beslishulp_contract.py
@@ -1,0 +1,229 @@
+"""
+Tests voor het contract tussen de externe beslishulp AI-verordening en de
+labelmapping in docs/javascripts/modal.js.
+
+De beslishulp draait in een iframe en zet zijn uitkomst in sessionStorage onder
+"labelsbysubcategory": een object {subcategorie: [antwoordlabel, ...]}. modal.js
+plakt die twee samen tot "<subcategorie>-<antwoordlabel>" en zoekt dat op in
+labelMapper. Staat de combinatie daar niet in, dan krijgt het label het
+achtervoegsel "[onbekend]" en filtert updateLabels() het weg -- de dimensie
+verdwijnt dan geruisloos uit het filter.
+
+Zo brak het filteren toen de beslishulp in v1.2.15 de subcategorie "Rol"
+hernoemde naar "Verantwoordelijkheid": modal.js kende alleen nog "Rol-aanbieder".
+Deze tests vergelijken de gepinde beslishulp-bundle met de mapping in modal.js,
+zodat zo'n hernoeming bij de volgende versiebump direct opvalt.
+"""
+
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BESLISHULP_HTML = REPO_ROOT / "docs/html/beslishulp.html"
+MODAL_JS = REPO_ROOT / "docs/javascripts/modal.js"
+
+DOWNLOAD_ATTEMPTS = 3
+DOWNLOAD_TIMEOUT = 60
+
+
+# --------------------------------------------------------------------------
+# modal.js: de labelmapping uitlezen
+# --------------------------------------------------------------------------
+
+# labelMapper.addEntry('aanbieder', 'Aanbieder', 'rol-ai-act', ["Rol-aanbieder"]);
+ADD_ENTRY = re.compile(
+    r"labelMapper\.addEntry\(\s*"
+    r"'([^']*)'\s*,\s*"  # label
+    r"'([^']*)'\s*,\s*"  # display_value
+    r"'([^']*)'\s*"  # group
+    r"(?:,\s*\[([^\]]*)\])?\s*"  # synoniemen (optioneel)
+    r"\)"
+)
+
+
+def modal_synonyms() -> set[str]:
+    """Alle sleutels waarop labelMapper.find() een treffer geeft, lowercase.
+
+    Dat zijn zowel de canonieke "<group>-<label>" sleutels als de synoniemen;
+    ValueMapper.addEntry() registreert beide en zoekt lowercase op.
+    """
+    source = MODAL_JS.read_text(encoding="utf-8")
+    keys: set[str] = set()
+
+    for label, _display, group, synonyms in ADD_ENTRY.findall(source):
+        keys.add(f"{group}-{label}".lower())
+        if synonyms:
+            # modal.js gebruikt door elkaar enkele en dubbele quotes
+            keys.update(
+                s.lower() for s in re.findall(r"""['"]([^'"]*)['"]""", synonyms)
+            )
+
+    assert keys, "geen labelMapper.addEntry() aanroepen gevonden in modal.js"
+    return keys
+
+
+# --------------------------------------------------------------------------
+# beslishulp: het gepinde bundel uitlezen
+# --------------------------------------------------------------------------
+
+
+def beslishulp_url() -> str:
+    match = re.search(
+        r'src="(https://github\.com/[^"]+/index\.js)"',
+        BESLISHULP_HTML.read_text(encoding="utf-8"),
+    )
+    assert match, f"geen beslishulp script-URL gevonden in {BESLISHULP_HTML}"
+    return match.group(1)
+
+
+@pytest.fixture(scope="session")
+def beslishulp_bundle() -> str:
+    """De gepinde beslishulp-bundle, eenmalig opgehaald per testsessie."""
+    url = beslishulp_url()
+    last_error: Exception | None = None
+
+    for _ in range(DOWNLOAD_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response:
+                return response.read().decode("utf-8", errors="replace")
+        except (urllib.error.URLError, TimeoutError) as error:  # pragma: no cover
+            last_error = error
+
+    pytest.fail(f"kon beslishulp-bundle niet ophalen van {url}: {last_error}")
+
+
+def subcategories(bundle: str) -> set[str]:
+    """De sleutels van labelsbysubcategory, uit het initiele sjabloon.
+
+    De beslishulp initialiseert de store met een JSON-sjabloon waarin elke
+    subcategorie op ["nader te bepalen"] staat; dat sjabloon is de enige plek
+    waar alle sleutels compleet bij elkaar staan.
+    """
+    keys = set(re.findall(r'"([^"]+)":\s*\["nader te bepalen"\]', bundle))
+    assert keys, "geen labelsbysubcategory-sjabloon gevonden in de beslishulp-bundle"
+    return keys
+
+
+def answer_labels(bundle: str) -> set[str]:
+    """Alle antwoordlabels die de beslishulp aan een subcategorie kan toekennen.
+
+    Staan in de vragenlijst als labels:[`aanbieder`,...]. De gebruikte
+    quotestijl verschilt per minifier-versie, vandaar beide varianten.
+    """
+    labels: set[str] = set()
+    for array in re.findall(r"labels:\[([^\]]*)\]", bundle):
+        labels.update(re.findall(r"[`\"']([^`\"']+)[`\"']", array))
+
+    labels.discard("nader te bepalen")
+    assert labels, "geen antwoordlabels gevonden in de beslishulp-bundle"
+    return labels
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_modal_kent_elke_subcategorie_van_de_beslishulp(beslishulp_bundle: str):
+    """Elke subcategorie moet als voorvoegsel in de mapping voorkomen.
+
+    Vangt hernoemingen als "Rol" -> "Verantwoordelijkheid": zonder passend
+    voorvoegsel valt de hele dimensie uit het vereistenfilter.
+    """
+    synonyms = modal_synonyms()
+
+    missing = sorted(
+        subcategory
+        for subcategory in subcategories(beslishulp_bundle)
+        if not any(key.startswith(f"{subcategory.lower()}-") for key in synonyms)
+    )
+
+    assert not missing, (
+        f"modal.js kent geen mapping voor subcategorie(en) {missing} van "
+        f"{beslishulp_url()}. Voeg synoniemen '<subcategorie>-<antwoord>' toe aan "
+        f"labelMapper in {MODAL_JS.relative_to(REPO_ROOT)}."
+    )
+
+
+def test_modal_kent_elk_antwoordlabel_van_de_beslishulp(beslishulp_bundle: str):
+    """Elk antwoordlabel moet als achtervoegsel in de mapping voorkomen.
+
+    Vangt hernoemde antwoorden, bijvoorbeeld "hoog-risico AI" -> iets anders.
+    """
+    synonyms = modal_synonyms()
+
+    missing = sorted(
+        label
+        for label in answer_labels(beslishulp_bundle)
+        if not any(key.endswith(f"-{label.lower()}") for key in synonyms)
+    )
+
+    assert not missing, (
+        f"modal.js kent geen mapping voor antwoordlabel(s) {missing} van "
+        f"{beslishulp_url()}. Vul de bijbehorende synoniemen aan in labelMapper in "
+        f"{MODAL_JS.relative_to(REPO_ROOT)}."
+    )
+
+
+def test_uitkomst_van_de_beslishulp_levert_alle_filterlabels_op():
+    """Een volledige beslishulp-uitkomst moet op alle zes filterdimensies mappen.
+
+    Offline regressietest voor de bug waarbij de rol-dimensie wegviel: hier
+    staat letterlijk wat de beslishulp oplevert en wat het filter ervan moet
+    maken. De twee genegeerde groepen ('operationeel',
+    'conformiteitsbeoordelingsinstantie') laat updateLabels() zelf vallen.
+    """
+    # given - uitkomst voor een aanbieder van een hoog-risico AI-systeem
+    labels_by_subcategory = {
+        "Verantwoordelijkheid": ["aanbieder"],
+        "Operationeel": ["in gebruik"],
+        "Soort toepassing": ["AI-systeem"],
+        "Risicogroep": ["hoog-risico AI"],
+        "Conformiteitsbeoordelingsinstantie": ["niet van toepassing"],
+        "Systeemrisico": ["niet van toepassing"],
+        "Transparantieverplichting": ["geen transparantieverplichting"],
+        "Open source": ["geen open-source"],
+    }
+
+    # when - modal.js plakt subcategorie en antwoord aan elkaar en zoekt dat op
+    synonyms = modal_synonyms()
+    unmapped = [
+        f"{subcategory}-{value}"
+        for subcategory, values in labels_by_subcategory.items()
+        for value in values
+        if f"{subcategory}-{value}".lower() not in synonyms
+    ]
+
+    # then - geen enkele combinatie mag als "[onbekend]" wegvallen
+    assert not unmapped, (
+        f"deze beslishulp-uitkomsten mappen niet: {unmapped}. "
+        f"Ze krijgen '[onbekend]' en worden door updateLabels() weggefilterd, "
+        f"waardoor die filterdimensie stilletjes niets meer doet."
+    )
+
+
+def test_beslishulp_uitkomst_dekt_de_gedocumenteerde_subcategorieen(
+    beslishulp_bundle: str,
+):
+    """De regressietest hierboven moet de echte subcategorieen blijven gebruiken."""
+    documented = {
+        "Verantwoordelijkheid",
+        "Operationeel",
+        "Soort toepassing",
+        "Risicogroep",
+        "Conformiteitsbeoordelingsinstantie",
+        "Systeemrisico",
+        "Transparantieverplichting",
+        "Open source",
+    }
+
+    assert subcategories(beslishulp_bundle) == documented, (
+        "de subcategorieen van de beslishulp zijn gewijzigd; werk "
+        f"test_uitkomst_van_de_beslishulp_levert_alle_filterlabels_op bij. "
+        f"Nu in de bundle: {json.dumps(sorted(subcategories(beslishulp_bundle)))}"
+    )

--- a/tests/modal/test_beslishulp_contract.py
+++ b/tests/modal/test_beslishulp_contract.py
@@ -9,10 +9,16 @@ labelMapper. Staat de combinatie daar niet in, dan krijgt het label het
 achtervoegsel "[onbekend]" en filtert updateLabels() het weg -- de dimensie
 verdwijnt dan geruisloos uit het filter.
 
-Zo brak het filteren toen de beslishulp in v1.2.15 de subcategorie "Rol"
-hernoemde naar "Verantwoordelijkheid": modal.js kende alleen nog "Rol-aanbieder".
-Deze tests vergelijken de gepinde beslishulp-bundle met de mapping in modal.js,
-zodat zo'n hernoeming bij de volgende versiebump direct opvalt.
+Zo brak het filteren toen de beslishulp de subcategorie "Rol" hernoemde naar
+"Verantwoordelijkheid": modal.js kende alleen nog "Rol-aanbieder", waardoor de
+rol-dimensie niets meer deed.
+
+De kern van deze tests is test_modal_kent_elke_uitkomst_van_de_beslishulp: die
+leidt uit de gepinde bundle af welke *combinaties* van subcategorie en
+antwoordlabel de beslishulp daadwerkelijk kan opleveren, en controleert dat
+modal.js ze allemaal kent. Losse controles op subcategorie en antwoordlabel zijn
+niet genoeg -- die blijven groen als beide namen wel ergens in de mapping
+voorkomen maar niet in die combinatie.
 """
 
 import json
@@ -29,6 +35,10 @@ MODAL_JS = REPO_ROOT / "docs/javascripts/modal.js"
 
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_TIMEOUT = 60
+
+# De beslishulp-bundle is geminificeerd; welke quotestijl de minifier kiest
+# verschilt per versie (v1.2.24 gebruikt backticks).
+Q = r"['\"`]"
 
 
 # --------------------------------------------------------------------------
@@ -109,19 +119,74 @@ def subcategories(bundle: str) -> set[str]:
     return keys
 
 
-def answer_labels(bundle: str) -> set[str]:
-    """Alle antwoordlabels die de beslishulp aan een subcategorie kan toekennen.
+def question_subcategories(bundle: str) -> dict[str, str]:
+    """De categorielijst van de beslishulp: questionId -> subcategorie."""
+    pairs = re.findall(
+        rf"questionId:{Q}([^'\"`]+){Q},category:{Q}[^'\"`]*{Q},subcategory:{Q}([^'\"`]+){Q}",
+        bundle,
+    )
+    assert pairs, "geen questionId/subcategory-lijst gevonden in de beslishulp-bundle"
+    return dict(pairs)
 
-    Staan in de vragenlijst als labels:[`aanbieder`,...]. De gebruikte
-    quotestijl verschilt per minifier-versie, vandaar beide varianten.
+
+def resolve_subcategory(question_id: str, by_question: dict[str, str]) -> str | None:
+    """De subcategorie die de beslishulp bij een vraag zoekt.
+
+    Spiegelt de lookup in de bundle: die probeert achtereenvolgens "1", "1.4" en
+    "1.4.1" en houdt de langste treffer over. Vraag 1.4.1 staat dus niet zelf in
+    de lijst maar erft "Soort toepassing" van 1.4.
     """
-    labels: set[str] = set()
-    for array in re.findall(r"labels:\[([^\]]*)\]", bundle):
-        labels.update(re.findall(r"[`\"']([^`\"']+)[`\"']", array))
+    parts = question_id.split(".")
+    found = by_question.get(parts[0])
+    for depth in (2, 3):
+        if len(parts) >= depth:
+            deeper = by_question.get(".".join(parts[:depth]))
+            if deeper is not None:
+                found = deeper
+    return found
 
-    labels.discard("nader te bepalen")
-    assert labels, "geen antwoordlabels gevonden in de beslishulp-bundle"
-    return labels
+
+def outcome_pairs(bundle: str) -> set[tuple[str, str]]:
+    """Alle (subcategorie, antwoordlabel) combinaties die de beslishulp oplevert.
+
+    De bundle koppelt een antwoordlabel aan een subcategorie via de vraag waar
+    het antwoord bij hoort (addLabelBySubCategory(label, subcategory)). We lopen
+    de bundle daarom op volgorde af en hangen elke labels:[...] aan de laatst
+    geziene questionId.
+    """
+    by_question = question_subcategories(bundle)
+
+    events: list[tuple[int, str, str]] = []
+    # `nextQuestionId` matcht hier niet op: dat heeft een hoofdletter Q.
+    for match in re.finditer(rf"(?<![A-Za-z])questionId:{Q}([^'\"`]+){Q}", bundle):
+        events.append((match.start(), "vraag", match.group(1)))
+    for match in re.finditer(r"labels:\[([^\]]*)\]", bundle):
+        events.append((match.start(), "labels", match.group(1)))
+    events.sort()
+
+    pairs: set[tuple[str, str]] = set()
+    current: str | None = None
+    for _, kind, value in events:
+        if kind == "vraag":
+            current = value
+            continue
+        if current is None:
+            continue
+        subcategory = resolve_subcategory(current, by_question)
+        if subcategory is None or subcategory == "Conclusie":
+            continue
+        for label in re.findall(rf"{Q}([^'\"`]+){Q}", value):
+            pairs.add((subcategory, label))
+
+    assert pairs, "geen antwoordlabels gevonden in de beslishulp-bundle"
+
+    # Bij de conclusie zet de beslishulp elke subcategorie die niet aan bod kwam
+    # van "nader te bepalen" op "niet van toepassing" (updateLabelsAtConclusion),
+    # dus die combinatie kan voor iedere subcategorie voorbijkomen.
+    for subcategory in subcategories(bundle):
+        pairs.add((subcategory, "niet van toepassing"))
+
+    return pairs
 
 
 # --------------------------------------------------------------------------
@@ -129,49 +194,31 @@ def answer_labels(bundle: str) -> set[str]:
 # --------------------------------------------------------------------------
 
 
-def test_modal_kent_elke_subcategorie_van_de_beslishulp(beslishulp_bundle: str):
-    """Elke subcategorie moet als voorvoegsel in de mapping voorkomen.
+def test_modal_kent_elke_uitkomst_van_de_beslishulp(beslishulp_bundle: str):
+    """Elke combinatie die de beslishulp kan opleveren moet modal.js kennen.
 
-    Vangt hernoemingen als "Rol" -> "Verantwoordelijkheid": zonder passend
-    voorvoegsel valt de hele dimensie uit het vereistenfilter.
+    Dit is de test die de "Rol" -> "Verantwoordelijkheid" hernoeming vangt: niet
+    of beide namen ergens voorkomen, maar of "<subcategorie>-<antwoord>" precies
+    zo in labelMapper staat. Zo niet, dan valt die filterdimensie stil weg.
     """
     synonyms = modal_synonyms()
 
     missing = sorted(
-        subcategory
-        for subcategory in subcategories(beslishulp_bundle)
-        if not any(key.startswith(f"{subcategory.lower()}-") for key in synonyms)
+        f"{subcategory}-{label}"
+        for subcategory, label in outcome_pairs(beslishulp_bundle)
+        if f"{subcategory}-{label}".lower() not in synonyms
     )
 
     assert not missing, (
-        f"modal.js kent geen mapping voor subcategorie(en) {missing} van "
-        f"{beslishulp_url()}. Voeg synoniemen '<subcategorie>-<antwoord>' toe aan "
-        f"labelMapper in {MODAL_JS.relative_to(REPO_ROOT)}."
-    )
-
-
-def test_modal_kent_elk_antwoordlabel_van_de_beslishulp(beslishulp_bundle: str):
-    """Elk antwoordlabel moet als achtervoegsel in de mapping voorkomen.
-
-    Vangt hernoemde antwoorden, bijvoorbeeld "hoog-risico AI" -> iets anders.
-    """
-    synonyms = modal_synonyms()
-
-    missing = sorted(
-        label
-        for label in answer_labels(beslishulp_bundle)
-        if not any(key.endswith(f"-{label.lower()}") for key in synonyms)
-    )
-
-    assert not missing, (
-        f"modal.js kent geen mapping voor antwoordlabel(s) {missing} van "
-        f"{beslishulp_url()}. Vul de bijbehorende synoniemen aan in labelMapper in "
-        f"{MODAL_JS.relative_to(REPO_ROOT)}."
+        f"modal.js kent deze uitkomst(en) van {beslishulp_url()} niet: {missing}. "
+        f"Voeg ze als synoniem toe aan labelMapper in "
+        f"{MODAL_JS.relative_to(REPO_ROOT)}, anders krijgen ze '[onbekend]' en "
+        f"filtert die dimensie niet meer mee."
     )
 
 
 def test_uitkomst_van_de_beslishulp_levert_alle_filterlabels_op():
-    """Een volledige beslishulp-uitkomst moet op alle zes filterdimensies mappen.
+    """Een volledige beslishulp-uitkomst moet op alle filterdimensies mappen.
 
     Offline regressietest voor de bug waarbij de rol-dimensie wegviel: hier
     staat letterlijk wat de beslishulp oplevert en wat het filter ervan moet
@@ -207,10 +254,42 @@ def test_uitkomst_van_de_beslishulp_levert_alle_filterlabels_op():
     )
 
 
+def test_elke_subcategorie_kent_niet_van_toepassing():
+    """"niet van toepassing" moet voor elke subcategorie gemapt zijn.
+
+    Bij de conclusie krijgt elke subcategorie die niet aan bod kwam deze waarde.
+    updateLabels() filtert hem daarna weg op display_value, maar zonder mapping
+    komt hij eerst als onbekend label langs en waarschuwt find() bij elke
+    doorloop van de beslishulp.
+    """
+    synonyms = modal_synonyms()
+
+    documented = {
+        "Verantwoordelijkheid",
+        "Operationeel",
+        "Soort toepassing",
+        "Risicogroep",
+        "Conformiteitsbeoordelingsinstantie",
+        "Systeemrisico",
+        "Transparantieverplichting",
+        "Open source",
+    }
+
+    missing = sorted(
+        subcategory
+        for subcategory in documented
+        if f"{subcategory}-niet van toepassing".lower() not in synonyms
+    )
+
+    assert not missing, (
+        f"modal.js mist '<subcategorie>-niet van toepassing' voor {missing}."
+    )
+
+
 def test_beslishulp_uitkomst_dekt_de_gedocumenteerde_subcategorieen(
     beslishulp_bundle: str,
 ):
-    """De regressietest hierboven moet de echte subcategorieen blijven gebruiken."""
+    """De offline tests hierboven moeten de echte subcategorieen blijven gebruiken."""
     documented = {
         "Verantwoordelijkheid",
         "Operationeel",


### PR DESCRIPTION
De embed zat sinds juli 2025 vast op v1.2.15, omdat er vanaf v1.2.16 geen index.js meer als release-asset verscheen. Dat is nu opgelost in de bron: MinBZK/ai-verordening-beslishulp#1046 repareert release-package.yml (trigger 'published' i.p.v. 'created', de generatiestappen voor decision-tree.json/categories.json, en GITHUB_TOKEN i.p.v. een verlopen PAT). De asset voor v1.2.24 is daarna alsnog gepubliceerd.

Geverifieerd:
- De asset is byte-identiek (sha256 ca6d751f..., 3.837.284 bytes) aan zowel de bundle in ghcr.io/minbzk/ai-verordening-beslishulp:1.2.24 als aan een lokale build vanaf tag v1.2.24.
- Headless render van docs/html/beslishulp.html geeft met v1.2.24 exact dezelfde zichtbare tekst als met v1.2.15.
- De download redirect naar release-assets.githubusercontent.com, die al in de CSP van de container-branch staat.

## Beschrijf jouw aanpassingen

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review
- [ ] Ik heb de [contributing guidelines](https://github.com/MinBZK/Algoritmekader/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [ ] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [ ] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [ ] Ik heb gebruik gemaakt van de templates en formats van het algoritmekader.
